### PR TITLE
test fail instead of skipping

### DIFF
--- a/.github/workflows/tests-01-main.yml
+++ b/.github/workflows/tests-01-main.yml
@@ -198,7 +198,7 @@ jobs:
               fi
             fi
           else
-            STATUS="skip"
+            STATUS="fail"
             ERROR_MSG="Package not in supported list"
           fi
 


### PR DESCRIPTION
potential fix for the CI to catch packages that are missing a manifest entry